### PR TITLE
Pathing localization error

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -552,9 +552,9 @@
 
       "PATHING": {
         "Name": "Pathing Roll",
-        "CriticalSuccess": "Pathing Roll",
+        "Critical": "On a mixed or success, the adventurers go the way the players want them to.",
         "Success": "On a mixed or success, the adventurers go the way the players want them to.",
-        "MixedSuccess": "On a mixed or success, the adventurers go the way the players want them to.",
+        "Mixed": "On a mixed or success, the adventurers go the way the players want them to.",
         "Failure": "On a mixed or success, the adventurers go the way the players want them to. On a failure, <strong>they go the other way.</strong>"
       },
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -544,7 +544,7 @@
 
       "STARTING": {
         "Name": "Starting Location Roll",
-        "Critical": "StartingLoc Roll",
+        "Critical": "A success starts you off in a good position. You begin in the exact dungeon room you want to be in with weapons nearby.",
         "Success": "A success starts you off in a good position. You begin in the exact dungeon room you want to be in with weapons nearby.",
         "Mixed": "A mixed starts you off in a less than ideal situation. You might not have weapons or maybe just not begin in a great location. You're likely busy doing some other task.",
         "Failure": "A failure starts you off in a terrible position. You're far from the action, rather distracted by something you're doing, likely without weapons, or maybe even sleeping. The adventurers have a decisive advantage against you."


### PR DESCRIPTION
Replaced `PATHING.MixedSuccess` and `CriticalSuccess` with `Mixed` and `Critical`, respectively.

Also copied Success text into Critical for Pathing and Starting location rolls, just in case someone wanted to give them bonus dice.